### PR TITLE
TaskTableViewCell周り、俺ならこうするっての修正してみました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# xcode noise
+build/*
+*.perspective
+*.perspectivev3
+*.pbxuser
+*.xcworkspace
+*.mode1
+*.mode2v3
+*.mode1v3
+xcuserdata
+Snapshots
+
+# old skool
+.svn
+
+# osx noise
+.DS_Store
+out/
+
+.idea/
+
+# CocoaPods
+Pods/
+*.xcworkspace/
+
+# bundle
+vendor/
+.bundle
+fastlane/report.xml
+*.ipa
+*.app.dSYM.zip
+certs/*.mobileprovision
+
+.envrc
+
+Carthage
+Settings.bundle/Acknowledgements.plist

--- a/TODO_APP_swift/Task.swift
+++ b/TODO_APP_swift/Task.swift
@@ -11,7 +11,7 @@ import UIKit
 class Task: NSObject, NSCoding {
     //MARK: Propeties
     var title: String
-    var limit: NSDate?
+    var limit: Date?
     var completed: Bool
     var detailDescription: String?
 
@@ -28,7 +28,7 @@ class Task: NSObject, NSCoding {
     }
 
     //MARK: Initialization
-    init?(title: String, limit: NSDate?, completed: Bool, detailDescription: String?) {
+    init?(title: String, limit: Date?, completed: Bool, detailDescription: String?) {
         // title must not be empty
         guard !title.isEmpty else {
             return nil
@@ -54,7 +54,7 @@ class Task: NSObject, NSCoding {
             return nil
         }
 
-        let limit = aDecoder.decodeObject(forKey: PropertyKey.limit) as? NSDate
+        let limit = aDecoder.decodeObject(forKey: PropertyKey.limit) as? Date
 
         let completed = aDecoder.decodeBool(forKey: PropertyKey.completed)
 

--- a/TODO_APP_swift/TaskTableViewCell.swift
+++ b/TODO_APP_swift/TaskTableViewCell.swift
@@ -11,18 +11,17 @@ import UIKit
 class TaskTableViewCell: UITableViewCell {
 
     //MARK: Propeties
-    @IBOutlet weak var taskTitle: UILabel!
-    @IBOutlet weak var taskLimit: UILabel!
+    @IBOutlet private weak var taskTitle: UILabel!
+    @IBOutlet private weak var taskLimit: UILabel!
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    func prepare(task: Task) {
+        taskTitle.text = task.title
+        taskLimit.text = task.limit.map { dateFormatter.string(from: $0) }
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
+    
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
 }

--- a/TODO_APP_swift/TaskTableViewController.swift
+++ b/TODO_APP_swift/TaskTableViewController.swift
@@ -156,23 +156,8 @@ class TaskTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cellIdentifier = "TaskTableViewCell"
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? TaskTableViewCell else {
-            fatalError("The dequeud cell is not an instance of TaskTableViewCell")
-        }
-
-        let task = tasksForTable[indexPath.row]
-
-        cell.taskTitle.text = task.title
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        if let limit = task.limit {
-            cell.taskLimit.text = dateFormatter.string(from: limit as Date)
-        } else {
-            cell.taskLimit.text = nil
-        }
-
+        let cell = tableView.dequeueReusableCell(withIdentifier: "TaskTableViewCell", for: indexPath) as! TaskTableViewCell
+        cell.prepare(task: tasksForTable[indexPath.row])
         return cell
     }
 

--- a/TODO_APP_swift/TaskViewController.swift
+++ b/TODO_APP_swift/TaskViewController.swift
@@ -162,9 +162,9 @@ class TaskViewController: UIViewController, UITextFieldDelegate, UITextViewDeleg
         }
 
         let title = titleTextField.text ?? ""
-        var limit: NSDate?
+        var limit: Date?
         if let limitStr = limitTextField.text, !limitStr.isEmpty {
-            limit = dateFormatter.date(from: limitStr)! as NSDate
+            limit = dateFormatter.date(from: limitStr)! as Date
         }
         let completed: Bool
         if completeButton.titleLabel?.font == UIFont(name: "FontAwesome", size: 50) {


### PR DESCRIPTION
- 余計なメソッドは削除する
- fat controllerにならないように、初期化処理等はcellの方に責任をもたせる
- メソッド呼び出しでidentifierであることは分かるので一旦変数に入れないほうがかえって読みやすい（と俺は思う）
- どうせクラッシュさせるだけならforce castする（ほうが読みやすいと俺は思う）
- NSDateは古いのでDateを使う